### PR TITLE
Fix AST cleanup double free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Makefile
 
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c99 -g -Isrc
+# Enable POSIX/GNU extensions so functions like strdup/strndup are declared
+CFLAGS = -Wall -Wextra -std=c99 -g -Isrc -D_GNU_SOURCE
 SRC_DIR = src
 BUILD_DIR = build
 

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -2,33 +2,39 @@
 
 #include "ast/ast.h"
 
+static void free_node(ASTNode *n)
+{
+    if (!n)
+        return;
+
+    if (n->type == NODE_SET)
+    {
+        free(n->set_name);
+        if (n->is_copy)
+        {
+            free(n->copy_from_var);
+        }
+        else
+        {
+            free_value(n->literal_value); // deep free for VAL_OBJECT
+        }
+    }
+    else if (n->type == NODE_FUNC_CALL)
+    {
+        free(n->func_name);
+        for (int j = 0; j < n->arg_count; j++)
+            free_node(n->args[j]);
+        free(n->args);
+    }
+
+    free(n);
+}
+
 void free_ast(ASTNode **nodes, int count)
 {
     for (int i = 0; i < count; i++)
     {
-        ASTNode *n = nodes[i];
-
-        if (n->type == NODE_SET)
-        {
-            free(n->set_name);
-            if (n->is_copy)
-            {
-                free(n->copy_from_var);
-            }
-            else
-            {
-                free_value(n->literal_value); // deep free for VAL_OBJECT
-            }
-        }
-        else if (n->type == NODE_FUNC_CALL)
-        {
-            free(n->func_name);
-            for (int j = 0; j < n->arg_count; j++)
-                free_ast(&n->args[j], 1);
-            free(n->args);
-        }
-
-        free(n);
+        free_node(nodes[i]);
     }
 
     free(nodes);


### PR DESCRIPTION
## Summary
- prevent double free by avoiding recursive freeing of array elements
- compile with `_GNU_SOURCE` to ensure POSIX functions are declared

## Testing
- `make clean >/tmp/make.log && make >/tmp/make.log`
- `./build/able_exe examples/objects.abl`


------
https://chatgpt.com/codex/tasks/task_e_688064f2a0b88330b38f18ed88aaf5e7