### PR TITLE
Support attribute assignment

### DIFF
--- a/examples/attr_set.abl
+++ b/examples/attr_set.abl
@@ -1,0 +1,5 @@
+set person to {name: {first: "Ada"}}
+set person.age to 30
+set person.country to "Wonderland"
+pr(person.age)
+pr(person.country)

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -23,6 +23,8 @@ static void free_node(ASTNode *n)
     if (n->type == NODE_SET)
     {
         free(n->set_name);
+        if (n->set_attr)
+            free_node(n->set_attr);
 
         if (n->is_copy)
         {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -24,6 +24,7 @@ typedef struct ASTNode
 
     // SET
     char *set_name;
+    struct ASTNode *set_attr; // destination attribute chain if assigning to attr
     Value literal_value;
     bool is_copy;
     char *copy_from_var;            // for basic copy

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -33,7 +33,14 @@ void run_ast(ASTNode **nodes, int count)
                 result = clone_value(&n->literal_value);
             }
 
-            set_variable(n->set_name, result);
+            if (n->set_attr)
+            {
+                assign_attribute_chain(n->set_attr, result);
+            }
+            else
+            {
+                set_variable(n->set_name, result);
+            }
         }
 
         else if (n->type == NODE_FUNC_CALL)

--- a/src/interpreter/resolve.c
+++ b/src/interpreter/resolve.c
@@ -30,3 +30,41 @@ Value resolve_attribute_chain(ASTNode *attr_node)
 
     return base;
 }
+
+void assign_attribute_chain(ASTNode *attr_node, Value val)
+{
+    Value base_val = get_variable(attr_node->object_name);
+    if (base_val.type != VAL_OBJECT)
+    {
+        fprintf(stderr, "Error: '%s' is not an object\n", attr_node->object_name);
+        exit(1);
+    }
+
+    Object *obj = base_val.obj;
+    for (int i = 0; i < attr_node->child_count - 1; ++i)
+    {
+        ASTNode *seg = attr_node->children[i];
+        Value next = object_get(obj, seg->attr_name);
+
+        if (next.type == VAL_NULL)
+        {
+            Object *new_obj = malloc(sizeof(Object));
+            new_obj->count = 0;
+            new_obj->capacity = 0;
+            new_obj->pairs = NULL;
+            Value new_val = {.type = VAL_OBJECT, .obj = new_obj};
+            object_set(obj, seg->attr_name, new_val);
+            next = new_val;
+        }
+        else if (next.type != VAL_OBJECT)
+        {
+            fprintf(stderr, "Error: intermediate '%s' is not an object\n", seg->attr_name);
+            exit(1);
+        }
+
+        obj = next.obj;
+    }
+
+    ASTNode *last = attr_node->children[attr_node->child_count - 1];
+    object_set(obj, last->attr_name, val);
+}

--- a/src/interpreter/resolve.h
+++ b/src/interpreter/resolve.h
@@ -5,5 +5,6 @@
 #include "ast/ast.h"
 
 Value resolve_attribute_chain(struct ASTNode *attr_node);
+void assign_attribute_chain(struct ASTNode *attr_node, Value val);
 
 #endif


### PR DESCRIPTION
## Summary
- allow setting attributes in SET statements
- parse source/destination as chained identifiers
- expose helper for assigning attribute chains
- update interpreter to use new helper
- add attribute assignment example

## Testing
- `make`
- `./build/able_exe examples/attr_set.abl`

------
https://chatgpt.com/codex/tasks/task_e_6880db2c3c0c83309186b4078955f48a