### PR TITLE
Enable empty pr() calls to print newline

### DIFF
--- a/examples/example.abl
+++ b/examples/example.abl
@@ -1,5 +1,5 @@
 set name to "Daniel"
 set age to 22
 
-pr(name)
-pr(age)
+pr(name, age)
+pr()

--- a/examples/objects.abl
+++ b/examples/objects.abl
@@ -3,7 +3,8 @@ set person to {name: { f_name: "Hof", l_name: "Coral"}, age: 22}
 # This is a comments
 set my_name to person.name
 
-pr(my_name.f_name)
+pr("First name:", my_name.f_name)
+pr()
 
 
 ##

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -39,6 +39,11 @@ static void free_node(ASTNode *n)
         }
     }
 
+    if (n->type == NODE_LITERAL)
+    {
+        free_value(n->literal_value);
+    }
+
     if (n->type == NODE_FUNC_CALL)
     {
         free(n->func_name);

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -11,7 +11,8 @@ typedef enum
     NODE_SET,
     NODE_VAR,
     NODE_FUNC_CALL,
-    NODE_ATTR_ACCESS
+    NODE_ATTR_ACCESS,
+    NODE_LITERAL
 } NodeType;
 
 typedef struct ASTNode


### PR DESCRIPTION
## Summary
- support zero arguments in `pr()` by removing the argument count check
- show the new behavior in examples

## Testing
- `make`
- `./build/able_exe examples/example.abl`
- `./build/able_exe examples/objects.abl`


------
https://chatgpt.com/codex/tasks/task_e_6881421f1af08330b8c96987092b6353