### PR TITLE
Add return statement support

### DIFF
--- a/examples/return_example.abl
+++ b/examples/return_example.abl
@@ -1,0 +1,2 @@
+set echo to (value): return value
+pr(echo("test"))

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -12,7 +12,8 @@ typedef enum
     NODE_VAR,
     NODE_FUNC_CALL,
     NODE_ATTR_ACCESS,
-    NODE_LITERAL
+    NODE_LITERAL,
+    NODE_RETURN
 } NodeType;
 
 typedef struct ASTNode

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -10,6 +10,8 @@
 #include "interpreter/interpreter.h"
 #include "utils/utils.h"
 
+static Value exec_func_call(ASTNode *n);
+
 static Value eval_node(ASTNode *n)
 {
     switch (n->type)
@@ -20,14 +22,51 @@ static Value eval_node(ASTNode *n)
         return resolve_attribute_chain(n);
     case NODE_LITERAL:
         return clone_value(&n->literal_value);
+    case NODE_FUNC_CALL:
+        return exec_func_call(n);
     default:
         log_error("Unsupported eval node type");
         exit(1);
     }
 }
 
-void run_ast(ASTNode **nodes, int count)
+static Value exec_func_call(ASTNode *n)
 {
+    if (n->func_callee->type == NODE_VAR && strcmp(n->func_callee->set_name, "pr") == 0)
+    {
+        for (int j = 0; j < n->child_count; ++j)
+        {
+            Value val = eval_node(n->children[j]);
+            print_value(val, 0);
+            if (j < n->child_count - 1)
+                printf(" ");
+        }
+        printf("\n");
+        Value undef = {.type = VAL_UNDEFINED};
+        return undef;
+    }
+
+    Value callee_val = eval_node(n->func_callee);
+    if (callee_val.type != VAL_FUNCTION)
+    {
+        log_error("Attempting to call non-function");
+        Value undef = {.type = VAL_UNDEFINED};
+        return undef;
+    }
+
+    Function *fn = callee_val.func;
+    for (int p = 0; p < fn->param_count && p < n->child_count; ++p)
+    {
+        Value arg_val = eval_node(n->children[p]);
+        set_variable(fn->params[p], arg_val);
+    }
+
+    return run_ast(fn->body, fn->body_count);
+}
+
+Value run_ast(ASTNode **nodes, int count)
+{
+    Value last = {.type = VAL_UNDEFINED};
     for (int i = 0; i < count; ++i)
     {
         ASTNode *n = nodes[i];
@@ -59,37 +98,16 @@ void run_ast(ASTNode **nodes, int count)
                 set_variable(n->set_name, result);
             }
         }
-
         else if (n->type == NODE_FUNC_CALL)
         {
-            if (n->func_callee->type == NODE_VAR && strcmp(n->func_callee->set_name, "pr") == 0)
-            {
-                for (int j = 0; j < n->child_count; ++j)
-                {
-                    Value val = eval_node(n->children[j]);
-                    print_value(val, 0);
-                    if (j < n->child_count - 1)
-                        printf(" ");
-                }
-                printf("\n");
-                continue;
-            }
-
-            Value callee_val = eval_node(n->func_callee);
-
-            if (callee_val.type != VAL_FUNCTION)
-            {
-                log_error("Attempting to call non-function");
-                continue;
-            }
-
-            Function *fn = callee_val.func;
-            for (int p = 0; p < fn->param_count && p < n->child_count; ++p)
-            {
-                Value arg_val = eval_node(n->children[p]);
-                set_variable(fn->params[p], arg_val);
-            }
-            run_ast(fn->body, fn->body_count);
+            exec_func_call(n);
+        }
+        else if (n->type == NODE_RETURN)
+        {
+            last = eval_node(n->children[0]);
+            return last;
         }
     }
+
+    return last;
 }

--- a/src/interpreter/interpreter.h
+++ b/src/interpreter/interpreter.h
@@ -2,7 +2,8 @@
 #define INTERPRETER_H
 
 #include "ast/ast.h"
+#include "types/value.h"
 
-void run_ast(ASTNode **nodes, int count);
+Value run_ast(ASTNode **nodes, int count);
 
 #endif

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -120,6 +120,8 @@ Token next_token(Lexer *lexer)
             return make_token(TOKEN_GET, start, len);
         if (strncmp(start, "POST", len) == 0)
             return make_token(TOKEN_POST, start, len);
+        if (strncmp(start, "return", len) == 0)
+            return make_token(TOKEN_RETURN, start, len);
 
         return make_token(TOKEN_IDENTIFIER, start, len);
     }

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -17,6 +17,7 @@ typedef enum
     TOKEN_ASSIGN,
     TOKEN_GET,
     TOKEN_POST,
+    TOKEN_RETURN,
     TOKEN_LPAREN,
     TOKEN_RPAREN,
     TOKEN_LBRACE,

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -15,6 +15,7 @@ static Token current;
 static Lexer *L;
 
 static ASTNode *parse_statement();
+static ASTNode *parse_return_stmt();
 
 static void advance_token() { current = next_token(L); }
 
@@ -242,13 +243,13 @@ static ASTNode *parse_set_stmt()
     return n;
 }
 
-static ASTNode *parse_func_call()
+static ASTNode *finish_func_call(ASTNode *callee)
 {
     ASTNode *n = new_node(NODE_FUNC_CALL);
-    n->func_callee = parse_identifier_chain();
+    n->func_callee = callee;
 
-    if (n->func_callee->type == NODE_VAR)
-        n->func_name = strdup(n->func_callee->set_name);
+    if (callee->type == NODE_VAR)
+        n->func_name = strdup(callee->set_name);
     else
         n->func_name = NULL;
 
@@ -273,11 +274,22 @@ static ASTNode *parse_func_call()
     return n;
 }
 
+static ASTNode *parse_func_call()
+{
+    ASTNode *callee = parse_identifier_chain();
+    return finish_func_call(callee);
+}
+
 ASTNode *parse_argument()
 {
     if (current.type == TOKEN_IDENTIFIER)
     {
-        return parse_identifier_chain();
+        ASTNode *node = parse_identifier_chain();
+        if (current.type == TOKEN_LPAREN)
+        {
+            return finish_func_call(node);
+        }
+        return node;
     }
     else if (current.type == TOKEN_STRING || current.type == TOKEN_NUMBER || current.type == TOKEN_LBRACE)
     {
@@ -370,10 +382,20 @@ ASTNode *parse_object_literal()
     return obj_node;
 }
 
+static ASTNode *parse_return_stmt()
+{
+    ASTNode *n = new_node(NODE_RETURN);
+    ASTNode *expr = parse_argument();
+    add_child(n, expr);
+    return n;
+}
+
 static ASTNode *parse_statement()
 {
     if (match(TOKEN_SET))
         return parse_set_stmt();
+    if (match(TOKEN_RETURN))
+        return parse_return_stmt();
     if (current.type == TOKEN_IDENTIFIER)
         return parse_func_call();
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,6 +8,7 @@ EXAMPLES = {
     'examples/attr_set.abl': '30.000000\nWonderland\n',
     'examples/main.abl': 'Hello World!\n',
     'examples/objects.abl': 'First name: Hof\n\n',
+    'examples/return_example.abl': 'test\n',
 }
 
 class ExampleTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- extend lexer with TOKEN_RETURN
- add NODE_RETURN type for AST
- enable return statements and function call expressions in parser
- implement returning values in the interpreter
- provide a return statement example and include in tests

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688159a728648330af5fdfc8c2aa82a1