### PR TITLE
Modify pr function formatting

### DIFF
--- a/examples/functions/print_function.abl
+++ b/examples/functions/print_function.abl
@@ -1,0 +1,2 @@
+set greet to (name): pr(name)
+pr(greet)

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -43,8 +43,6 @@ static Value exec_func_call(ASTNode *n)
         {
             Value val = eval_node(n->children[j]);
             print_value(val, 0);
-            if (j < n->child_count - 1)
-                printf(" ");
         }
         printf("\n");
         Value undef = {.type = VAL_UNDEFINED};

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -188,10 +188,12 @@ static Function *parse_function_def()
     }
 
     Function *fn = malloc(sizeof(Function));
+    fn->name = NULL;
     fn->param_count = count;
     fn->params = params;
     fn->body = body;
     fn->body_count = body_count;
+    fn->env = NULL;
     return fn;
 }
 
@@ -277,6 +279,7 @@ static ASTNode *parse_set_stmt()
     if (current.type == TOKEN_LPAREN)
     {
         Function *fn = parse_function_def();
+        fn->name = strdup(n->set_name);
         n->literal_value.type = VAL_FUNCTION;
         n->literal_value.func = fn;
         n->is_copy = false;

--- a/src/types/function.c
+++ b/src/types/function.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "types/function.h"
+#include "types/env.h"
 
 void free_function(Function *fn)
 {
@@ -11,6 +12,9 @@ void free_function(Function *fn)
     for (int i = 0; i < fn->param_count; ++i)
         free(fn->params[i]);
     free(fn->params);
+    free(fn->name);
+    if (fn->env)
+        env_release(fn->env);
     if (fn->body)
     {
         for (int i = 0; i < fn->body_count; ++i)

--- a/src/types/function.h
+++ b/src/types/function.h
@@ -7,6 +7,7 @@ struct Env;
 
 typedef struct Function
 {
+    char *name;
     int param_count;
     char **params;
     ASTNode **body;

--- a/src/types/value.c
+++ b/src/types/value.c
@@ -4,6 +4,7 @@
 
 #include "types/value.h"
 #include "types/object.h"
+#include "types/function.h"
 
 void free_value(Value v)
 {
@@ -104,7 +105,15 @@ void print_value(Value v, int indent)
         break;
 
     case VAL_FUNCTION:
-        printf("<function>");
+        if (v.func)
+        {
+            const char *fname = v.func->name ? v.func->name : "anonymous";
+            printf("<function: %s at %p>", fname, (void *)v.func);
+        }
+        else
+        {
+            printf("<function: NULL>");
+        }
         break;
 
     default:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,15 +4,15 @@ from pathlib import Path
 
 EXE = Path('build/able_exe')
 EXAMPLES = {
-    'examples/variables/basic_assignment.abl': 'Daniel 22.000000\n\n',
+    'examples/variables/basic_assignment.abl': 'Daniel22.000000\n\n',
     'examples/objects/attr_set.abl': '30.000000\nWonderland\n',
     'examples/variables/simple_print.abl': 'Hello World!\n',
-    'examples/objects/object_literal.abl': 'First name: Hof\n\n',
+    'examples/objects/object_literal.abl': 'First name:Hof\n\n',
     'examples/functions/return_example.abl': 'test\n',
     'examples/functions/assign_from_return.abl': 'hello\n',
     'examples/variables/bool.abl': 'true\nfalse\n',
     'examples/variables/copy.abl': 'Alice\n',
-    'examples/functions/greet.abl': 'Alice Wonderland\n',
+    'examples/functions/greet.abl': 'AliceWonderland\n',
     'examples/functions/choose_first.abl': 'x\n',
 }
 
@@ -32,6 +32,10 @@ class ExampleTests(unittest.TestCase):
             with self.subTest(example=file):
                 output = self.run_example(file)
                 self.assertEqual(output, expected)
+
+    def test_function_print(self):
+        output = self.run_example('examples/functions/print_function.abl')
+        self.assertRegex(output, r'^<function: greet at 0x[0-9a-fA-F]+>\n$')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- attach names to functions and store them
- show function name and address when printing
- remove spaces between printed args
- adjust test expectations for new output and check function string

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6882946c51bc833098a08bccdcca11dd