### PR TITLE
Implement type() builtin and null literal

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -3,6 +3,8 @@
 
 import subprocess
 import sys
+import tempfile
+import os
 import unittest
 
 
@@ -14,9 +16,35 @@ def main():
     if not result.wasSuccessful():
         print("Not all tests passed.")
         sys.exit(1)
-    else:
-        print("All tests passed.")
-        sys.exit(0)
+
+    def run(code):
+        with tempfile.NamedTemporaryFile("w", suffix=".abl", delete=False) as f:
+            f.write(code)
+            temp_path = f.name
+        try:
+            out = subprocess.run(["build/able_exe", temp_path], check=True, capture_output=True, text=True)
+            return out.stdout
+        finally:
+            os.unlink(temp_path)
+
+    def run_raises(code):
+        try:
+            run(code)
+        except subprocess.CalledProcessError:
+            return True
+        return False
+
+    assert run('set x to "foo"\npr(type(x))') == 'STRING\n'
+    assert run('set x to 123\npr(type(x))') == 'NUMBER\n'
+    assert run('set x to true\npr(type(x))') == 'BOOLEAN\n'
+    assert run('set x to null\npr(type(x))') == 'NULL\n'
+    assert run('set x to {}\npr(type(x))') == 'OBJECT\n'
+    assert run('set f to (): return\npr(type(f))') == 'FUNCTION\n'
+    assert run_raises('pr(type())')
+    assert run_raises('pr(type(a,b))')
+
+    print("All tests passed.")
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -159,6 +159,19 @@ static Value exec_func_call(ASTNode *n)
         return undef;
     }
 
+    if (n->func_callee->type == NODE_VAR && strcmp(n->func_callee->set_name, "type") == 0)
+    {
+        if (n->child_count != 1)
+        {
+            log_error("type() expects exactly one argument");
+            exit(1);
+        }
+        Value arg = eval_node(n->children[0]);
+        const char *name = value_type_name(arg.type);
+        Value res = {.type = VAL_STRING, .str = strdup(name)};
+        return res;
+    }
+
     Value callee_val = eval_node(n->func_callee);
     if (callee_val.type != VAL_FUNCTION)
     {

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -172,22 +172,24 @@ Token next_token(Lexer *lexer)
 
         size_t len = &lexer->source[lexer->pos] - start;
 
-        if (strncmp(start, "set", len) == 0)
+        if (len == 3 && strncmp(start, "set", len) == 0)
             return make_token(TOKEN_SET, start, len);
-        if (strncmp(start, "to", len) == 0)
+        if (len == 2 && strncmp(start, "to", len) == 0)
             return make_token(TOKEN_TO, start, len);
-        if (strncmp(start, "pr", len) == 0)
+        if (len == 2 && strncmp(start, "pr", len) == 0)
             return make_token(TOKEN_IDENTIFIER, start, len);
-        if (strncmp(start, "GET", len) == 0)
+        if (len == 3 && strncmp(start, "GET", len) == 0)
             return make_token(TOKEN_GET, start, len);
-        if (strncmp(start, "POST", len) == 0)
+        if (len == 4 && strncmp(start, "POST", len) == 0)
             return make_token(TOKEN_POST, start, len);
-        if (strncmp(start, "return", len) == 0)
+        if (len == 6 && strncmp(start, "return", len) == 0)
             return make_token(TOKEN_RETURN, start, len);
-        if (strncmp(start, "true", len) == 0)
+        if (len == 4 && strncmp(start, "true", len) == 0)
             return make_token(TOKEN_TRUE, start, len);
-        if (strncmp(start, "false", len) == 0)
+        if (len == 5 && strncmp(start, "false", len) == 0)
             return make_token(TOKEN_FALSE, start, len);
+        if (len == 4 && strncmp(start, "null", len) == 0)
+            return make_token(TOKEN_NULL, start, len);
 
         return make_token(TOKEN_IDENTIFIER, start, len);
     }

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -16,6 +16,7 @@ typedef enum
     TOKEN_STRING,
     TOKEN_TRUE,
     TOKEN_FALSE,
+    TOKEN_NULL,
     TOKEN_ASSIGN,
     TOKEN_GET,
     TOKEN_POST,

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -109,6 +109,11 @@ static ASTNode *parse_literal_node()
         n->literal_value.boolean = (current.type == TOKEN_TRUE);
         advance_token();
     }
+    else if (current.type == TOKEN_NULL)
+    {
+        n->literal_value.type = VAL_NULL;
+        advance_token();
+    }
     else if (current.type == TOKEN_LBRACE)
     {
         ASTNode *obj = parse_object_literal();
@@ -382,7 +387,7 @@ static ASTNode *parse_primary()
     }
     else if (current.type == TOKEN_STRING || current.type == TOKEN_NUMBER ||
              current.type == TOKEN_TRUE || current.type == TOKEN_FALSE ||
-             current.type == TOKEN_LBRACE)
+             current.type == TOKEN_NULL || current.type == TOKEN_LBRACE)
     {
         return parse_literal_node();
     }
@@ -451,6 +456,11 @@ ASTNode *parse_object_literal()
             val.boolean = (current.type == TOKEN_TRUE);
             advance_token();
         }
+        else if (current.type == TOKEN_NULL)
+        {
+            val.type = VAL_NULL;
+            advance_token();
+        }
         else if (current.type == TOKEN_LBRACE)
         {
             ASTNode *inner_obj_node = parse_object_literal();
@@ -493,8 +503,17 @@ ASTNode *parse_object_literal()
 static ASTNode *parse_return_stmt()
 {
     ASTNode *n = new_node(NODE_RETURN);
-    ASTNode *expr = parse_expression();
-    add_child(n, expr);
+    if (current.type == TOKEN_NEWLINE || current.type == TOKEN_DEDENT || current.type == TOKEN_EOF)
+    {
+        ASTNode *undef = new_node(NODE_LITERAL);
+        undef->literal_value.type = VAL_UNDEFINED;
+        add_child(n, undef);
+    }
+    else
+    {
+        ASTNode *expr = parse_expression();
+        add_child(n, expr);
+    }
     return n;
 }
 

--- a/src/types/value.c
+++ b/src/types/value.c
@@ -6,6 +6,23 @@
 #include "types/object.h"
 #include "types/function.h"
 
+static const char *TYPE_NAMES[VAL_TYPE_COUNT] = {
+    "UNDEFINED",
+    "NULL",
+    "BOOLEAN",
+    "NUMBER",
+    "STRING",
+    "OBJECT",
+    "FUNCTION"
+};
+
+const char *value_type_name(ValueType type)
+{
+    if (type < 0 || type >= VAL_TYPE_COUNT)
+        return "UNKNOWN";
+    return TYPE_NAMES[type];
+}
+
 void free_value(Value v)
 {
     switch (v.type)

--- a/src/types/value.h
+++ b/src/types/value.h
@@ -16,6 +16,7 @@ typedef enum
     VAL_STRING,
     VAL_OBJECT,
     VAL_FUNCTION,
+    VAL_TYPE_COUNT
 } ValueType;
 
 // ————— VALUE STRUCT ————— //
@@ -36,5 +37,6 @@ typedef struct Value
 Value clone_value(const Value *src);
 void free_value(Value val);
 void print_value(Value v, int indent); // For debugging
+const char *value_type_name(ValueType type);
 
 #endif


### PR DESCRIPTION
## Summary
- support `null` values in the lexer and parser
- allow `return` without an expression
- expose `value_type_name()` lookup and add builtin `type()`
- add regression tests for `type()` behavior

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688554968e448330b0f34d0db5840dfc