### PR TITLE
Add line info to error logs

### DIFF
--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -12,11 +12,11 @@ void log_info(const char *fmt, ...)
     va_end(args);
 }
 
-void log_error(const char *fmt, ...)
+void log_error_loc(const char *file, int line, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    fprintf(stderr, "[ERROR] ");
+    fprintf(stderr, "[ERROR %s:%d] ", file, line);
     vfprintf(stderr, fmt, args);
     fprintf(stderr, "\n");
     va_end(args);

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -2,7 +2,8 @@
 #define UTILS_H
 
 void log_info(const char *fmt, ...);
-void log_error(const char *fmt, ...);
+void log_error_loc(const char *file, int line, const char *fmt, ...);
+#define log_error(fmt, ...) log_error_loc(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
 void log_debug(const char *fmt, ...);
 
 #endif


### PR DESCRIPTION
## Summary
- add log_error_loc function that prints file name and line number
- define log_error macro that wraps log_error_loc

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856abd12ec8330b139d96d4f3b559f