### PR TITLE
Enable integer-aware printing

### DIFF
--- a/src/types/value.c
+++ b/src/types/value.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 #include "types/value.h"
 #include "types/object.h"
@@ -85,7 +86,10 @@ void print_value(Value v, int indent)
         break;
 
     case VAL_NUMBER:
-        printf("%f", v.num);
+        if (fabs(v.num - (long long)v.num) < 1e-9)
+            printf("%lld", (long long)v.num);
+        else
+            printf("%f", v.num);
         break;
 
     case VAL_BOOL:

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -3,8 +3,8 @@ import unittest
 from tests.integration.helpers import AbleTestCase
 
 EXAMPLES = {
-    'examples/variables/basic_assignment.abl': 'Daniel22.000000\n\n',
-    'examples/objects/attr_set.abl': '30.000000\nWonderland\n',
+    'examples/variables/basic_assignment.abl': 'Daniel22\n\n',
+    'examples/objects/attr_set.abl': '30\nWonderland\n',
     'examples/variables/simple_print.abl': 'Hello World!\n',
     'examples/objects/object_literal.abl': 'First name:Hof\n\n',
     'examples/functions/return_example.abl': 'test\n',
@@ -13,7 +13,7 @@ EXAMPLES = {
     'examples/variables/copy.abl': 'Alice\n',
     'examples/functions/greet.abl': 'AliceWonderland\n',
     'examples/functions/choose_first.abl': 'x\n',
-    'examples/variables/math.abl': '5.000000\nHello World\n1.000000\n',
+    'examples/variables/math.abl': '5\nHello World\n1\n',
     'examples/variables/equality.abl': 'true\ntrue\nfalse\ntrue\n',
     'examples/variables/bool_func.abl': 'false\ntrue\nfalse\n',
     'examples/control/if_else.abl': 'B\n',


### PR DESCRIPTION
## Summary
- adjust number printing logic to omit decimal points for integer values
- update integration tests to match the new output format

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68867bcd02988330afaf47d13eef12c9