### PR TITLE
Implement call stack for Able interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRCS = \
     $(SRC_DIR)/types/function.c \
     $(SRC_DIR)/types/env.c \
     $(SRC_DIR)/interpreter/interpreter.c \
+    $(SRC_DIR)/interpreter/stack.c \
     $(SRC_DIR)/interpreter/resolve.c \
     $(SRC_DIR)/utils/utils.c
 

--- a/examples/functions/fib_recursion.abl
+++ b/examples/functions/fib_recursion.abl
@@ -1,0 +1,6 @@
+set fib to (n):
+    if n < 2:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+pr(fib(6))

--- a/src/interpreter/interpreter.h
+++ b/src/interpreter/interpreter.h
@@ -4,8 +4,12 @@
 #include "ast/ast.h"
 #include "types/value.h"
 #include "types/env.h"
+#include "interpreter/stack.h"
 
+void interpreter_init();
+void interpreter_cleanup();
 void interpreter_set_env(Env *env);
+Env *interpreter_current_env();
 Value run_ast(ASTNode **nodes, int count);
 
 #endif

--- a/src/interpreter/resolve.c
+++ b/src/interpreter/resolve.c
@@ -6,11 +6,12 @@
 #include "types/value.h"
 #include "ast/ast.h"
 #include "types/env.h"
+#include "interpreter/interpreter.h"
 #include "utils/utils.h"
 
 Value resolve_attribute_chain(ASTNode *attr_node)
 {
-    Value base = get_variable(current_env, attr_node->object_name, attr_node->line, attr_node->column);
+    Value base = get_variable(interpreter_current_env(), attr_node->object_name, attr_node->line, attr_node->column);
     if (base.type != VAL_OBJECT)
     {
         log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->object_name);
@@ -34,7 +35,7 @@ Value resolve_attribute_chain(ASTNode *attr_node)
 
 void assign_attribute_chain(ASTNode *attr_node, Value val)
 {
-    Value base_val = get_variable(current_env, attr_node->object_name, attr_node->line, attr_node->column);
+    Value base_val = get_variable(interpreter_current_env(), attr_node->object_name, attr_node->line, attr_node->column);
     if (base_val.type != VAL_OBJECT)
     {
         log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->object_name);

--- a/src/interpreter/stack.c
+++ b/src/interpreter/stack.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+#include "interpreter/stack.h"
+
+void stack_init(CallStack *stack)
+{
+    stack->frames = NULL;
+    stack->size = 0;
+    stack->capacity = 0;
+}
+
+void stack_free(CallStack *stack)
+{
+    free(stack->frames);
+    stack->frames = NULL;
+    stack->size = 0;
+    stack->capacity = 0;
+}
+
+void push_frame(CallStack *stack, CallFrame frame)
+{
+    if (stack->size >= stack->capacity)
+    {
+        stack->capacity = stack->capacity ? stack->capacity * 2 : 4;
+        stack->frames = realloc(stack->frames, stack->capacity * sizeof(CallFrame));
+    }
+    stack->frames[stack->size++] = frame;
+}
+
+void pop_frame(CallStack *stack)
+{
+    if (stack->size > 0)
+    {
+        stack->size--;
+    }
+}
+
+CallFrame *current_frame(CallStack *stack)
+{
+    if (stack->size == 0)
+        return NULL;
+    return &stack->frames[stack->size - 1];
+}

--- a/src/interpreter/stack.h
+++ b/src/interpreter/stack.h
@@ -1,0 +1,26 @@
+#ifndef STACK_H
+#define STACK_H
+
+#include "types/env.h"
+#include "ast/ast.h"
+#include <stdbool.h>
+
+typedef struct CallFrame {
+    Env *env;
+    struct ASTNode **return_ptr; // optional future use
+    bool returning;
+} CallFrame;
+
+typedef struct CallStack {
+    CallFrame *frames;
+    int size;
+    int capacity;
+} CallStack;
+
+void stack_init(CallStack *stack);
+void stack_free(CallStack *stack);
+void push_frame(CallStack *stack, CallFrame frame);
+void pop_frame(CallStack *stack);
+CallFrame *current_frame(CallStack *stack);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -58,8 +58,10 @@ int main(int argc, char *argv[])
     ASTNode **prog = parse_program(&lexer, &stmt_count);
 
     Env *global_env = env_create(NULL);
+    interpreter_init();
     interpreter_set_env(global_env);
     run_ast(prog, stmt_count);
+    interpreter_cleanup();
 
     // Run "Garbage Collection"
     free_ast(prog, stmt_count);

--- a/src/types/env.c
+++ b/src/types/env.c
@@ -6,8 +6,6 @@
 #include "types/value.h"
 #include "utils/utils.h"
 
-Env *current_env = NULL;
-
 Env *env_create(Env *parent)
 {
     Env *env = malloc(sizeof(Env));

--- a/src/types/env.h
+++ b/src/types/env.h
@@ -26,6 +26,4 @@ void env_release(Env *env);
 void set_variable(Env *env, const char *name, Value val);
 Value get_variable(Env *env, const char *name, int line, int column);
 
-extern Env *current_env;
-
 #endif

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -13,6 +13,7 @@ EXAMPLES = {
     'examples/variables/copy.abl': 'Alice\n',
     'examples/functions/greet.abl': 'AliceWonderland\n',
     'examples/functions/choose_first.abl': 'x\n',
+    'examples/functions/fib_recursion.abl': '8\n',
     'examples/variables/math.abl': '5\nHello World\n1\n',
     'examples/variables/equality.abl': 'true\ntrue\nfalse\ntrue\n',
     'examples/variables/bool_func.abl': 'false\ntrue\nfalse\n',


### PR DESCRIPTION
## Summary
- add `CallStack` implementation and integrate into interpreter
- push/pop frames on function calls and propagate returns
- compile new stack module
- test recursion with new Fibonacci example

## Testing
- `make`
- `python3 run_tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886956e1cf083309b1ab76502293bff