### PR TITLE
Add runtime Type registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ SRCS = \
     $(SRC_DIR)/parser/parser.c \
     $(SRC_DIR)/ast/ast.c \
     $(SRC_DIR)/types/object.c \
+    $(SRC_DIR)/types/type.c \
+    $(SRC_DIR)/types/type_registry.c \
     $(SRC_DIR)/types/value.c \
     $(SRC_DIR)/types/function.c \
     $(SRC_DIR)/types/env.c \

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -11,6 +11,7 @@
 #include "interpreter/interpreter.h"
 #include "interpreter/stack.h"
 #include "utils/utils.h"
+#include "types/type_registry.h"
 
 static CallStack call_stack;
 
@@ -93,10 +94,12 @@ static bool loose_equal(Value a, Value b)
 void interpreter_init()
 {
     stack_init(&call_stack);
+    type_registry_init();
 }
 
 void interpreter_cleanup()
 {
+    type_registry_cleanup();
     stack_free(&call_stack);
 }
 

--- a/src/types/type.c
+++ b/src/types/type.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include <string.h>
+#include "types/type.h"
+
+Type *type_create(const char *name, size_t size)
+{
+    Type *t = malloc(sizeof(Type));
+    if (!t)
+        return NULL;
+    t->name = name ? strdup(name) : NULL;
+    t->size = size;
+    t->methods = NULL;
+    t->parent = NULL;
+    return t;
+}
+
+void type_free(Type *type)
+{
+    if (!type)
+        return;
+    free((char *)type->name);
+    free(type);
+}

--- a/src/types/type.h
+++ b/src/types/type.h
@@ -1,0 +1,18 @@
+#ifndef TYPE_H
+#define TYPE_H
+
+#include <stddef.h>
+
+struct MethodTable; // forward declaration
+
+typedef struct Type {
+    const char *name;
+    size_t size;
+    struct MethodTable *methods;
+    struct Type *parent;
+} Type;
+
+Type *type_create(const char *name, size_t size);
+void type_free(Type *type);
+
+#endif

--- a/src/types/type_registry.c
+++ b/src/types/type_registry.c
@@ -1,0 +1,49 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "types/type_registry.h"
+
+#define MAX_TYPES 32
+
+static Type *types[MAX_TYPES];
+static int type_count = 0;
+
+static void register_type(Type *t)
+{
+    if (type_count < MAX_TYPES)
+        types[type_count++] = t;
+}
+
+void type_registry_init()
+{
+    type_count = 0;
+    // Register built-in types
+    register_type(type_create("undefined", 0));
+    register_type(type_create("null", 0));
+    register_type(type_create("bool", sizeof(bool)));
+    register_type(type_create("number", sizeof(double)));
+    register_type(type_create("string", sizeof(char*)));
+    register_type(type_create("object", sizeof(void*))); // placeholder
+    register_type(type_create("function", sizeof(void*))); // placeholder
+}
+
+void type_registry_cleanup()
+{
+    for (int i = 0; i < type_count; ++i)
+    {
+        type_free(types[i]);
+        types[i] = NULL;
+    }
+    type_count = 0;
+}
+
+Type *type_registry_get(const char *name)
+{
+    for (int i = 0; i < type_count; ++i)
+    {
+        if (strcmp(types[i]->name, name) == 0)
+            return types[i];
+    }
+    return NULL;
+}

--- a/src/types/type_registry.h
+++ b/src/types/type_registry.h
@@ -1,0 +1,10 @@
+#ifndef TYPE_REGISTRY_H
+#define TYPE_REGISTRY_H
+
+#include "types/type.h"
+
+void type_registry_init();
+void type_registry_cleanup();
+Type *type_registry_get(const char *name);
+
+#endif


### PR DESCRIPTION
## Summary
- introduce a `Type` struct and allocator functions
- register builtin types in a simple registry
- initialise and cleanup the registry from the interpreter

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6886a78e9f9483308372994a0335188b