### PR TITLE
Refactor AST layout to union-based structure

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -24,27 +24,27 @@ static void free_node(ASTNode *n)
 
     if (n->type == NODE_SET)
     {
-        free(n->set_name);
-        if (n->set_attr)
-            free_node(n->set_attr);
+        free(n->data.set.set_name);
+        if (n->data.set.set_attr)
+            free_node(n->data.set.set_attr);
     }
 
     if (n->type == NODE_LITERAL)
     {
-        free_value(n->literal_value);
+        free_value(n->data.lit.literal_value);
     }
 
     if (n->type == NODE_FUNC_CALL)
     {
-        free(n->func_name);
-        if (n->func_callee)
-            free_node(n->func_callee);
+        free(n->data.call.func_name);
+        if (n->data.call.func_callee)
+            free_node(n->data.call.func_callee);
     }
 
     if (n->type == NODE_ATTR_ACCESS)
     {
-        free(n->object_name);
-        free(n->attr_name);
+        free(n->data.attr.object_name);
+        free(n->data.attr.attr_name);
     }
 
     // Free any children (used for all types with nested structure)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -16,7 +16,9 @@ typedef enum
     NODE_RETURN,
     NODE_BINARY,
     NODE_IF,
-    NODE_BLOCK
+    NODE_BLOCK,
+    NODE_CLASS_DEF,
+    NODE_METHOD_DEF
 } NodeType;
 
 typedef enum
@@ -39,29 +41,43 @@ typedef struct ASTNode
     NodeType type;
 
     // Common
+    int line, column;
     struct ASTNode **children;
     int child_count;
 
-    // SET
-    char *set_name;
-    struct ASTNode *set_attr; // destination attribute chain if assigning to attr
+    // Node-specific data
+    union
+    {
+        struct
+        {
+            char *set_name;
+            struct ASTNode *set_attr;
+        } set;
 
-    // Attribute access
-    char *object_name;
-    char *attr_name;
+        struct
+        {
+            char *object_name;
+            char *attr_name;
+        } attr;
 
-    // Function call
-    char *func_name;
-    struct ASTNode *func_callee; // allow attribute based calls
+        struct
+        {
+            char *func_name;
+            struct ASTNode *func_callee;
+        } call;
 
-    // Binary expression
-    BinaryOp binary_op;
+        struct
+        {
+            BinaryOp op;
+        } binary;
 
-    // Literal value (used for NODE_LITERAL)
-    Value literal_value;
+        struct
+        {
+            Value literal_value;
+        } lit;
 
-    int line;
-    int column;
+        /* (add new kinds here—LIST_LITERAL, CLASS_DEF, FOR_LOOP, etc.) */
+    } data;
 
 } ASTNode;
 

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -97,7 +97,7 @@ static bool loose_equal(Value a, Value b)
 
 static Value resolve_attr_prefix(ASTNode *attr_node, int count)
 {
-    Value base = get_variable(interpreter_current_env(), attr_node->object_name,
+    Value base = get_variable(interpreter_current_env(), attr_node->data.attr.object_name,
                               attr_node->line, attr_node->column);
     for (int i = 0; i < count; ++i)
     {
@@ -106,10 +106,10 @@ static Value resolve_attr_prefix(ASTNode *attr_node, int count)
             log_script_error(attr_node->children[i]->line,
                               attr_node->children[i]->column,
                               "Error: intermediate '%s' is not an object",
-                              attr_node->children[i]->attr_name);
+                              attr_node->children[i]->data.attr.attr_name);
             exit(1);
         }
-        base = object_get(base.obj, attr_node->children[i]->attr_name);
+        base = object_get(base.obj, attr_node->children[i]->data.attr.attr_name);
     }
     return base;
 }
@@ -145,27 +145,27 @@ static Value eval_node(ASTNode *n)
     switch (n->type)
     {
     case NODE_VAR:
-        return get_variable(interpreter_current_env(), n->set_name, n->line, n->column);
+        return get_variable(interpreter_current_env(), n->data.set.set_name, n->line, n->column);
     case NODE_ATTR_ACCESS:
         return resolve_attribute_chain(n);
     case NODE_LITERAL:
-        return clone_value(&n->literal_value);
+        return clone_value(&n->data.lit.literal_value);
     case NODE_FUNC_CALL:
         return exec_func_call(n);
     case NODE_BINARY:
     {
         Value left = eval_node(n->children[0]);
         Value right = eval_node(n->children[1]);
-        if (n->binary_op == OP_EQ || n->binary_op == OP_STRICT_EQ)
+        if (n->data.binary.op == OP_EQ || n->data.binary.op == OP_STRICT_EQ)
         {
-            bool eq = n->binary_op == OP_EQ ? loose_equal(left, right)
+            bool eq = n->data.binary.op == OP_EQ ? loose_equal(left, right)
                                             : strict_equal(left, right);
             Value res = {.type = VAL_BOOL, .boolean = eq};
             return res;
         }
 
-        if (n->binary_op == OP_LT || n->binary_op == OP_GT ||
-            n->binary_op == OP_LTE || n->binary_op == OP_GTE)
+        if (n->data.binary.op == OP_LT || n->data.binary.op == OP_GT ||
+            n->data.binary.op == OP_LTE || n->data.binary.op == OP_GTE)
         {
             bool cmp;
             if ((left.type == VAL_NUMBER || left.type == VAL_BOOL) &&
@@ -173,7 +173,7 @@ static Value eval_node(ASTNode *n)
             {
                 double ln = to_number(left);
                 double rn = to_number(right);
-                switch (n->binary_op)
+                switch (n->data.binary.op)
                 {
                 case OP_LT:
                     cmp = ln < rn;
@@ -191,7 +191,7 @@ static Value eval_node(ASTNode *n)
             else if (left.type == VAL_STRING && right.type == VAL_STRING)
             {
                 int c = strcmp(left.str, right.str);
-                switch (n->binary_op)
+                switch (n->data.binary.op)
                 {
                 case OP_LT:
                     cmp = c < 0;
@@ -218,7 +218,7 @@ static Value eval_node(ASTNode *n)
         if (left.type == VAL_NUMBER && right.type == VAL_NUMBER)
         {
             Value res = {.type = VAL_NUMBER};
-            switch (n->binary_op)
+            switch (n->data.binary.op)
             {
             case OP_ADD:
                 res.num = left.num + right.num;
@@ -241,7 +241,7 @@ static Value eval_node(ASTNode *n)
             }
             return res;
         }
-        if (n->binary_op == OP_ADD && left.type == VAL_STRING && right.type == VAL_STRING)
+        if (n->data.binary.op == OP_ADD && left.type == VAL_STRING && right.type == VAL_STRING)
         {
             size_t len1 = strlen(left.str);
             size_t len2 = strlen(right.str);
@@ -252,7 +252,7 @@ static Value eval_node(ASTNode *n)
             Value res = {.type = VAL_STRING, .str = buf};
             return res;
         }
-        if (n->binary_op == OP_ADD && left.type == VAL_LIST && right.type == VAL_LIST)
+        if (n->data.binary.op == OP_ADD && left.type == VAL_LIST && right.type == VAL_LIST)
         {
             List *list = malloc(sizeof(List));
             list->count = 0;
@@ -296,7 +296,7 @@ static Value eval_node(ASTNode *n)
 
 static Value exec_func_call(ASTNode *n)
 {
-    if (n->func_callee->type == NODE_VAR && strcmp(n->func_callee->set_name, "pr") == 0)
+    if (n->data.call.func_callee->type == NODE_VAR && strcmp(n->data.call.func_callee->data.set.set_name, "pr") == 0)
     {
         for (int j = 0; j < n->child_count; ++j)
         {
@@ -308,7 +308,7 @@ static Value exec_func_call(ASTNode *n)
         return undef;
     }
 
-    if (n->func_callee->type == NODE_VAR && strcmp(n->func_callee->set_name, "type") == 0)
+    if (n->data.call.func_callee->type == NODE_VAR && strcmp(n->data.call.func_callee->data.set.set_name, "type") == 0)
     {
         if (n->child_count != 1)
         {
@@ -321,7 +321,7 @@ static Value exec_func_call(ASTNode *n)
         return res;
     }
 
-    if (n->func_callee->type == NODE_VAR && strcmp(n->func_callee->set_name, "bool") == 0)
+    if (n->data.call.func_callee->type == NODE_VAR && strcmp(n->data.call.func_callee->data.set.set_name, "bool") == 0)
     {
         if (n->child_count != 1)
         {
@@ -333,7 +333,7 @@ static Value exec_func_call(ASTNode *n)
         return res;
     }
 
-    if (n->func_callee->type == NODE_VAR && strcmp(n->func_callee->set_name, "list") == 0)
+    if (n->data.call.func_callee->type == NODE_VAR && strcmp(n->data.call.func_callee->data.set.set_name, "list") == 0)
     {
         if (n->child_count > 1)
         {
@@ -361,13 +361,13 @@ static Value exec_func_call(ASTNode *n)
         return res;
     }
 
-    if (n->func_callee->type == NODE_ATTR_ACCESS)
+    if (n->data.call.func_callee->type == NODE_ATTR_ACCESS)
     {
-        ASTNode *attr = n->func_callee;
+        ASTNode *attr = n->data.call.func_callee;
         if (attr->child_count > 0)
         {
             ASTNode *last = attr->children[attr->child_count - 1];
-            const char *name = last->attr_name;
+            const char *name = last->data.attr.attr_name;
             Value target = resolve_attr_prefix(attr, attr->child_count - 1);
             if (target.type == VAL_LIST)
             {
@@ -435,7 +435,7 @@ static Value exec_func_call(ASTNode *n)
         }
     }
 
-    Value callee_val = eval_node(n->func_callee);
+    Value callee_val = eval_node(n->data.call.func_callee);
     if (callee_val.type != VAL_FUNCTION)
     {
         log_script_error(n->line, n->column, "Attempting to call non-function");
@@ -449,7 +449,7 @@ static Value exec_func_call(ASTNode *n)
     if (callee_val.func->param_count != n->child_count)
     {
         log_script_error(n->line, n->column, "Function '%s' expects %d arguments, but got %d",
-                  n->func_name,
+                  n->data.call.func_name,
                   fn->param_count,
                   n->child_count);
         exit(1);
@@ -481,9 +481,9 @@ Value run_ast(ASTNode **nodes, int count)
         {
             Value result = eval_node(n->children[0]);
 
-            if (n->set_attr)
+            if (n->data.set.set_attr)
             {
-                assign_attribute_chain(n->set_attr, result);
+                assign_attribute_chain(n->data.set.set_attr, result);
             }
             else
             {
@@ -492,7 +492,7 @@ Value run_ast(ASTNode **nodes, int count)
                     result.func->env = interpreter_current_env();
                     env_retain(interpreter_current_env());
                 }
-                set_variable(interpreter_current_env(), n->set_name, result);
+                set_variable(interpreter_current_env(), n->data.set.set_name, result);
             }
         }
         else if (n->type == NODE_FUNC_CALL)

--- a/src/interpreter/resolve.c
+++ b/src/interpreter/resolve.c
@@ -11,21 +11,21 @@
 
 Value resolve_attribute_chain(ASTNode *attr_node)
 {
-    Value base = get_variable(interpreter_current_env(), attr_node->object_name, attr_node->line, attr_node->column);
+    Value base = get_variable(interpreter_current_env(), attr_node->data.attr.object_name, attr_node->line, attr_node->column);
     if (base.type != VAL_OBJECT)
     {
-        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->object_name);
+        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->data.attr.object_name);
         exit(1);
     }
 
     for (int i = 0; i < attr_node->child_count; ++i)
     {
         ASTNode *seg = attr_node->children[i];
-        base = object_get(base.obj, seg->attr_name);
+        base = object_get(base.obj, seg->data.attr.attr_name);
 
         if (i < attr_node->child_count - 1 && base.type != VAL_OBJECT)
         {
-            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->attr_name);
+            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->data.attr.attr_name);
             exit(1);
         }
     }
@@ -35,10 +35,10 @@ Value resolve_attribute_chain(ASTNode *attr_node)
 
 void assign_attribute_chain(ASTNode *attr_node, Value val)
 {
-    Value base_val = get_variable(interpreter_current_env(), attr_node->object_name, attr_node->line, attr_node->column);
+    Value base_val = get_variable(interpreter_current_env(), attr_node->data.attr.object_name, attr_node->line, attr_node->column);
     if (base_val.type != VAL_OBJECT)
     {
-        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->object_name);
+        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->data.attr.object_name);
         exit(1);
     }
 
@@ -46,7 +46,7 @@ void assign_attribute_chain(ASTNode *attr_node, Value val)
     for (int i = 0; i < attr_node->child_count - 1; ++i)
     {
         ASTNode *seg = attr_node->children[i];
-        Value next = object_get(obj, seg->attr_name);
+        Value next = object_get(obj, seg->data.attr.attr_name);
 
         if (next.type == VAL_NULL)
         {
@@ -55,12 +55,12 @@ void assign_attribute_chain(ASTNode *attr_node, Value val)
             new_obj->capacity = 0;
             new_obj->pairs = NULL;
             Value new_val = {.type = VAL_OBJECT, .obj = new_obj};
-            object_set(obj, seg->attr_name, new_val);
+            object_set(obj, seg->data.attr.attr_name, new_val);
             next = new_val;
         }
         else if (next.type != VAL_OBJECT)
         {
-            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->attr_name);
+            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->data.attr.attr_name);
             exit(1);
         }
 
@@ -68,5 +68,5 @@ void assign_attribute_chain(ASTNode *attr_node, Value val)
     }
 
     ASTNode *last = attr_node->children[attr_node->child_count - 1];
-    object_set(obj, last->attr_name, val);
+    object_set(obj, last->data.attr.attr_name, val);
 }


### PR DESCRIPTION
## Summary
- extend `NodeType` with placeholders for class and method nodes
- reorganize `ASTNode` to store node-specific data in a union
- update parser to populate the new structure
- adjust interpreter and attribute resolution for the refactored AST

## Testing
- `make`
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6886d7f458808330aebeceb9d65b8d79