### PR TITLE
Refactor AST construction and access

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -17,34 +17,80 @@ void add_child(ASTNode *parent, ASTNode *child)
     parent->children[parent->child_count++] = child;
 }
 
+ASTNode *new_set_node(char *name, ASTNode *attr, int line, int column)
+{
+    ASTNode *n = new_node(NODE_SET, line, column);
+    n->data.set.set_name = name;
+    n->data.set.set_attr = attr;
+    return n;
+}
+
+ASTNode *new_var_node(char *name, int line, int column)
+{
+    ASTNode *n = new_node(NODE_VAR, line, column);
+    n->data.var.var_name = name;
+    return n;
+}
+
+ASTNode *new_attr_node(char *object, char *attr, int line, int column)
+{
+    ASTNode *n = new_node(NODE_ATTR_ACCESS, line, column);
+    n->data.attr.object_name = object;
+    n->data.attr.attr_name = attr;
+    return n;
+}
+
+ASTNode *new_func_call_node(ASTNode *callee, char *func_name, int line, int column)
+{
+    ASTNode *n = new_node(NODE_FUNC_CALL, line, column);
+    n->data.call.func_callee = callee;
+    n->data.call.func_name = func_name;
+    return n;
+}
+
+ASTNode *new_literal_node(Value value, int line, int column)
+{
+    ASTNode *n = new_node(NODE_LITERAL, line, column);
+    n->data.literal = value;
+    return n;
+}
+
+ASTNode *new_binary_node(BinaryOp op, int line, int column)
+{
+    ASTNode *n = new_node(NODE_BINARY, line, column);
+    n->data.binary.op = op;
+    return n;
+}
+
 static void free_node(ASTNode *n)
 {
     if (!n)
         return;
 
-    if (n->type == NODE_SET)
+    switch (n->type)
     {
-        free(n->set_name);
-        if (n->set_attr)
-            free_node(n->set_attr);
-    }
-
-    if (n->type == NODE_LITERAL)
-    {
-        free_value(n->literal_value);
-    }
-
-    if (n->type == NODE_FUNC_CALL)
-    {
-        free(n->func_name);
-        if (n->func_callee)
-            free_node(n->func_callee);
-    }
-
-    if (n->type == NODE_ATTR_ACCESS)
-    {
-        free(n->object_name);
-        free(n->attr_name);
+    case NODE_SET:
+        free(n->data.set.set_name);
+        if (n->data.set.set_attr)
+            free_node(n->data.set.set_attr);
+        break;
+    case NODE_VAR:
+        free(n->data.var.var_name);
+        break;
+    case NODE_FUNC_CALL:
+        free(n->data.call.func_name);
+        if (n->data.call.func_callee)
+            free_node(n->data.call.func_callee);
+        break;
+    case NODE_ATTR_ACCESS:
+        free(n->data.attr.object_name);
+        free(n->data.attr.attr_name);
+        break;
+    case NODE_LITERAL:
+        free_value(n->data.literal);
+        break;
+    default:
+        break;
     }
 
     // Free any children (used for all types with nested structure)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -42,23 +42,33 @@ typedef struct ASTNode
     struct ASTNode **children;
     int child_count;
 
-    // SET
-    char *set_name;
-    struct ASTNode *set_attr; // destination attribute chain if assigning to attr
-
-    // Attribute access
-    char *object_name;
-    char *attr_name;
-
-    // Function call
-    char *func_name;
-    struct ASTNode *func_callee; // allow attribute based calls
-
-    // Binary expression
-    BinaryOp binary_op;
-
-    // Literal value (used for NODE_LITERAL)
-    Value literal_value;
+    union
+    {
+        struct
+        {
+            char *set_name;
+            struct ASTNode *set_attr; // destination attribute chain if assigning to attr
+        } set;
+        struct
+        {
+            char *var_name;
+        } var;
+        struct
+        {
+            char *object_name;
+            char *attr_name;
+        } attr;
+        struct
+        {
+            char *func_name;
+            struct ASTNode *func_callee; // allow attribute based calls
+        } call;
+        struct
+        {
+            BinaryOp op;
+        } binary;
+        Value literal;
+    } data;
 
     int line;
     int column;
@@ -68,6 +78,13 @@ typedef struct ASTNode
 /* Helpers */
 ASTNode *new_node(NodeType type, int line, int column);
 void add_child(ASTNode *parent, ASTNode *child);
+
+ASTNode *new_set_node(char *name, ASTNode *attr, int line, int column);
+ASTNode *new_var_node(char *name, int line, int column);
+ASTNode *new_attr_node(char *object, char *attr, int line, int column);
+ASTNode *new_func_call_node(ASTNode *callee, char *func_name, int line, int column);
+ASTNode *new_literal_node(Value value, int line, int column);
+ASTNode *new_binary_node(BinaryOp op, int line, int column);
 
 /* Cleanup */
 void free_ast(ASTNode **nodes, int count);

--- a/src/interpreter/resolve.c
+++ b/src/interpreter/resolve.c
@@ -11,21 +11,21 @@
 
 Value resolve_attribute_chain(ASTNode *attr_node)
 {
-    Value base = get_variable(interpreter_current_env(), attr_node->object_name, attr_node->line, attr_node->column);
+    Value base = get_variable(interpreter_current_env(), attr_node->data.attr.object_name, attr_node->line, attr_node->column);
     if (base.type != VAL_OBJECT)
     {
-        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->object_name);
+        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->data.attr.object_name);
         exit(1);
     }
 
     for (int i = 0; i < attr_node->child_count; ++i)
     {
         ASTNode *seg = attr_node->children[i];
-        base = object_get(base.obj, seg->attr_name);
+        base = object_get(base.obj, seg->data.attr.attr_name);
 
         if (i < attr_node->child_count - 1 && base.type != VAL_OBJECT)
         {
-            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->attr_name);
+            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->data.attr.attr_name);
             exit(1);
         }
     }
@@ -35,10 +35,10 @@ Value resolve_attribute_chain(ASTNode *attr_node)
 
 void assign_attribute_chain(ASTNode *attr_node, Value val)
 {
-    Value base_val = get_variable(interpreter_current_env(), attr_node->object_name, attr_node->line, attr_node->column);
+    Value base_val = get_variable(interpreter_current_env(), attr_node->data.attr.object_name, attr_node->line, attr_node->column);
     if (base_val.type != VAL_OBJECT)
     {
-        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->object_name);
+        log_script_error(attr_node->line, attr_node->column, "Error: '%s' is not an object", attr_node->data.attr.object_name);
         exit(1);
     }
 
@@ -46,7 +46,7 @@ void assign_attribute_chain(ASTNode *attr_node, Value val)
     for (int i = 0; i < attr_node->child_count - 1; ++i)
     {
         ASTNode *seg = attr_node->children[i];
-        Value next = object_get(obj, seg->attr_name);
+        Value next = object_get(obj, seg->data.attr.attr_name);
 
         if (next.type == VAL_NULL)
         {
@@ -55,18 +55,18 @@ void assign_attribute_chain(ASTNode *attr_node, Value val)
             new_obj->capacity = 0;
             new_obj->pairs = NULL;
             Value new_val = {.type = VAL_OBJECT, .obj = new_obj};
-            object_set(obj, seg->attr_name, new_val);
+            object_set(obj, seg->data.attr.attr_name, new_val);
             next = new_val;
         }
         else if (next.type != VAL_OBJECT)
         {
-            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->attr_name);
-            exit(1);
+            log_script_error(seg->line, seg->column, "Error: intermediate '%s' is not an object", seg->data.attr.attr_name);
+        exit(1);
         }
 
         obj = next.obj;
     }
 
     ASTNode *last = attr_node->children[attr_node->child_count - 1];
-    object_set(obj, last->attr_name, val);
+    object_set(obj, last->data.attr.attr_name, val);
 }


### PR DESCRIPTION
## Summary
- add a union-based `ASTNode` layout
- add helper constructors for building AST nodes
- switch interpreter and resolver to new data fields
- refactor parser to use constructors

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6886eb0e04ec8330acf8db849a2f03b2