### PR TITLE
Add 'to' assignment syntax

### DIFF
--- a/examples/oop/class.abl
+++ b/examples/oop/class.abl
@@ -1,9 +1,9 @@
 class Person():
 
     set init to (this, first_name, last_name, age):
-        this.first_name = first_name
-        this.last_name = last_name
-        this.age = age
+        this.first_name to first_name
+        this.last_name to last_name
+        this.age to age
 
     
     set greet to (this):


### PR DESCRIPTION
## Summary
- support `to` assignments for identifiers without `set`
- update parser for new `this.name to value` syntax
- adjust class example to use new constructor syntax

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68878dec3cc48330a6bd4f93e75d3250