### PR TITLE
Enable integer iteration in for loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ pr(name)
 set numbers to [1, 2]
 numbers.append(3)
 pr(numbers.get(2))
+
+# Integer loops
+for i of 3:
+    pr(i)
 ```
 ```able
 # Class usage

--- a/examples/control/for_number.abl
+++ b/examples/control/for_number.abl
@@ -1,0 +1,2 @@
+for i of 5:
+    pr(i)

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -723,7 +723,31 @@ Value run_ast(ASTNode **nodes, int count)
         {
             Value iterable = eval_node(n->children[0]);
             ASTNode *body = n->children[1];
-            if (iterable.type == VAL_LIST)
+            if (iterable.type == VAL_NUMBER)
+            {
+                int limit = (int)iterable.num;
+                for (int i = 0; i < limit; ++i)
+                {
+                    Value idx = {.type = VAL_NUMBER, .num = i};
+                    set_variable(interpreter_current_env(), n->data.loop.loop_var,
+                                 idx);
+                    last = run_ast(body->children, body->child_count);
+                    CallFrame *cf = current_frame(&call_stack);
+                    if (cf && cf->returning)
+                        break;
+                    if (break_flag)
+                    {
+                        break_flag = false;
+                        break;
+                    }
+                    if (continue_flag)
+                    {
+                        continue_flag = false;
+                        continue;
+                    }
+                }
+            }
+            else if (iterable.type == VAL_LIST)
             {
                 for (int i = 0; i < iterable.list->count; ++i)
                 {

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -31,6 +31,7 @@ EXAMPLES = {
     'examples/types/function_type.abl': 'FUNCTION\n',
     'examples/variables/list_ops.abl': '1\n2\n3\n',
     'examples/control/for_loop.abl': '1\n2\n3\n',
+    'examples/control/for_number.abl': '0\n1\n2\n3\n4\n',
     'examples/control/while_loop.abl': '0\n1\n2\n',
     'examples/control/break_continue.abl': '1\n2\n',
 }


### PR DESCRIPTION
## Summary
- support numeric iteration in `for` loops
- add example and tests for integer loops
- document integer loop syntax in README

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6888065a619c8330a3f458000c380cc6