### PR TITLE
Add ternary operator support

### DIFF
--- a/examples/variables/ternary.abl
+++ b/examples/variables/ternary.abl
@@ -1,0 +1,4 @@
+set flag to true
+pr(flag ? "yes" : "no")
+set flag to false
+pr(flag ? "yes" : "no")

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -80,6 +80,16 @@ ASTNode *new_unary_node(UnaryOp op, ASTNode *expr, int line, int column)
     return n;
 }
 
+ASTNode *new_ternary_node(ASTNode *cond, ASTNode *true_expr, ASTNode *false_expr,
+                          int line, int column)
+{
+    ASTNode *n = new_node(NODE_TERNARY, line, column);
+    add_child(n, cond);
+    add_child(n, true_expr);
+    add_child(n, false_expr);
+    return n;
+}
+
 void add_child(ASTNode *parent, ASTNode *child)
 {
     parent->children = realloc(parent->children, sizeof(ASTNode *) * (parent->child_count + 1));

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -15,6 +15,7 @@ typedef enum
     NODE_LITERAL,
     NODE_RETURN,
     NODE_BINARY,
+    NODE_TERNARY,
     NODE_IF,
     NODE_BLOCK,
     NODE_CLASS_DEF,
@@ -145,6 +146,8 @@ ASTNode *new_import_names_node(char *module_name, char **names, int name_count,
                                int line, int column);
 ASTNode *new_postfix_inc_node(struct ASTNode *target);
 ASTNode *new_unary_node(UnaryOp op, struct ASTNode *expr, int line, int column);
+ASTNode *new_ternary_node(struct ASTNode *cond, struct ASTNode *true_expr,
+                          struct ASTNode *false_expr, int line, int column);
 void add_child(ASTNode *parent, ASTNode *child);
 
 /* Cleanup */

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -433,6 +433,13 @@ static Value eval_node(ASTNode *n)
         log_script_error(n->line, n->column, "Type error in binary expression");
         exit(1);
     }
+    case NODE_TERNARY:
+    {
+        Value cond = eval_node(n->children[0]);
+        if (to_boolean(cond))
+            return eval_node(n->children[1]);
+        return eval_node(n->children[2]);
+    }
     case NODE_IF:
     {
         Value cond = eval_node(n->children[0]);

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -335,6 +335,7 @@ Token next_token(Lexer *lexer)
         {'*', TOKEN_STAR},
         {'%', TOKEN_PERCENT},
         {'/', TOKEN_SLASH},
+        {'?', TOKEN_QUESTION},
     };
 
     for (size_t i = 0; i < sizeof(single_char_tokens) / sizeof(single_char_tokens[0]); ++i)

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -51,6 +51,7 @@ typedef enum
     TOKEN_STAR,
     TOKEN_SLASH,
     TOKEN_PERCENT,
+    TOKEN_QUESTION,
     TOKEN_EQ,
     TOKEN_STRICT_EQ,
     TOKEN_LT,

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -21,6 +21,8 @@ static ASTNode *parse_statement();
 static ASTNode *parse_return_stmt();
 static ASTNode *finish_func_call(ASTNode *callee);
 static ASTNode *parse_expression();
+static ASTNode *parse_ternary();
+static ASTNode *parse_logical();
 static ASTNode *parse_comparison();
 static ASTNode *parse_arithmetic();
 static ASTNode *parse_block();
@@ -586,7 +588,7 @@ static ASTNode *parse_comparison()
     return node;
 }
 
-static ASTNode *parse_expression()
+static ASTNode *parse_logical()
 {
     ASTNode *node = parse_comparison();
     while (current.type == TOKEN_AND || current.type == TOKEN_OR)
@@ -601,6 +603,26 @@ static ASTNode *parse_expression()
         node = bin;
     }
     return node;
+}
+
+static ASTNode *parse_ternary()
+{
+    ASTNode *condition = parse_logical();
+    if (match(TOKEN_QUESTION))
+    {
+        ASTNode *true_expr = parse_ternary();
+        expect(TOKEN_COLON, "':'");
+        ASTNode *false_expr = parse_ternary();
+        ASTNode *tern = new_ternary_node(condition, true_expr, false_expr,
+                                         prev_line, prev_col);
+        return tern;
+    }
+    return condition;
+}
+
+static ASTNode *parse_expression()
+{
+    return parse_ternary();
 }
 
 static ASTNode *parse_primary()

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -36,6 +36,7 @@ EXAMPLES = {
     'examples/control/break_continue.abl': '1\n2\n',
     'examples/variables/increment.abl': '0\n1\n',
     'examples/variables/logical_ops.abl': 'false\ntrue\ntrue\n',
+    'examples/variables/ternary.abl': 'yes\nno\n',
 }
 
 class ExampleTests(AbleTestCase):


### PR DESCRIPTION
## Summary
- add `?` token to lexer
- introduce `NODE_TERNARY` AST node and parser support
- evaluate ternary nodes in interpreter
- include new example script using the ternary operator
- test ternary operator via integration test

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688a28ee1abc8330b7e18e7b692db472