### PR TITLE
Add math.sqrt standard library support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ p.greet()
 ./build/able_exe examples/variables/basic_assignment.abl
 ```
 
+## Standard Library
+
+Able ships with a small standard library. Some functions are available
+globally, such as `abs`, `min` and `max`. Additional modules can be imported
+using `import`:
+
+```able
+import "math"
+pr(math.sqrt(9))
+```
+
 ## Development
 
 - Source code lives in `src/`.

--- a/examples/modules/import_sqrt.abl
+++ b/examples/modules/import_sqrt.abl
@@ -1,0 +1,2 @@
+import "math"
+pr(math.sqrt(9))

--- a/lib/math/__init__.abl
+++ b/lib/math/__init__.abl
@@ -1,1 +1,1 @@
-from "math/core" import add
+from "math/core" import add, sqrt

--- a/lib/math/core.abl
+++ b/lib/math/core.abl
@@ -1,2 +1,9 @@
 set add to (a, b):
     return a + b
+
+set sqrt to (x):
+    set guess to x / 2
+    set epsilon to 1 / 100000
+    while abs(guess * guess - x) > epsilon:
+        guess to (guess + x / guess) / 2
+    return guess

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -10,5 +10,9 @@ class ImportTests(AbleTestCase):
         output = self.run_script('examples/modules/from_import.abl')
         self.assertEqual(output, '5\n')
 
+    def test_math_sqrt(self):
+        output = self.run_script('examples/modules/import_sqrt.abl')
+        self.assertEqual(output, '3\n')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `sqrt` in the `math` module
- expose `sqrt` via `lib/math/__init__.abl`
- document the standard library in README
- add an example using `math.sqrt`
- test importing and calling `math.sqrt`

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688a3d435f8c8330ac8ba0453e7103fc