### PR TITLE
Implement private decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,18 @@ globally, such as `abs`, `min` and `max`. Additional modules can be imported
 using `import`:
 
 ```able
-import "math"
-pr(math.sqrt(9))
+from math import sqrt
+pr(sqrt(9))
 ```
+
+Custom modules can also be loaded from the working directory:
+
+```able
+from examples.custom_utils import greet
+pr(greet("Codex"))
+```
+
+Functions or variables marked with `@private` will not be exported when the module is imported.
 
 ## Development
 

--- a/examples/custom_utils/__init__.abl
+++ b/examples/custom_utils/__init__.abl
@@ -1,0 +1,9 @@
+@private
+set secret to 42
+
+set greet to (name):
+    return "Hello, " + name
+
+@private
+set hidden to ():
+    pr("hidden")

--- a/examples/modules/from_import.abl
+++ b/examples/modules/from_import.abl
@@ -1,2 +1,2 @@
-from "math" import add
+from math import add
 pr(add(2, 3))

--- a/examples/modules/import_custom.abl
+++ b/examples/modules/import_custom.abl
@@ -1,0 +1,2 @@
+from examples.custom_utils import greet
+pr(greet("Codex"))

--- a/examples/modules/import_module.abl
+++ b/examples/modules/import_module.abl
@@ -1,2 +1,2 @@
-import "math"
+import math
 pr(math.add(2, 3))

--- a/examples/modules/import_sqrt.abl
+++ b/examples/modules/import_sqrt.abl
@@ -1,2 +1,2 @@
-import "math"
-pr(math.sqrt(9))
+from math import sqrt
+pr(sqrt(9))

--- a/lib/math/__init__.abl
+++ b/lib/math/__init__.abl
@@ -1,1 +1,1 @@
-from "math/core" import add, sqrt
+from math.core import add, sqrt

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -10,6 +10,7 @@ ASTNode *new_node(NodeType type, int line, int column)
     n->line = line;
     n->column = column;
     n->is_static = false;
+    n->is_private = false;
     return n;
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -61,6 +61,7 @@ typedef struct ASTNode
     struct ASTNode **children;
     int child_count;
     bool is_static;
+    bool is_private;
 
     // Node-specific data
     union

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -873,7 +873,10 @@ Value run_ast(ASTNode **nodes, int count)
                     result.func->env = interpreter_current_env();
                     env_retain(interpreter_current_env());
                 }
-                set_variable(interpreter_current_env(), n->data.set.set_name, result);
+                if (n->is_private)
+                    set_private_variable(interpreter_current_env(), n->data.set.set_name, result);
+                else
+                    set_variable(interpreter_current_env(), n->data.set.set_name, result);
             }
             break;
         }

--- a/src/interpreter/module.c
+++ b/src/interpreter/module.c
@@ -82,7 +82,8 @@ static ModuleEntry *load_module(const char *name, int line, int column)
     obj->count = 0; obj->capacity = 0; obj->pairs = NULL;
     Variable *var, *tmp;
     HASH_ITER(hh, env->vars, var, tmp) {
-        object_set(obj, var->name, var->value);
+        if (!var->is_private)
+            object_set(obj, var->name, var->value);
     }
     Value val = { .type = VAL_OBJECT, .obj = obj };
 

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -270,6 +270,8 @@ Token next_token(Lexer *lexer)
         size_t len = &lexer->source[lexer->pos] - start;
         if (len == 6 && strncmp(start, "static", len) == 0)
             return make_token(TOKEN_AT_STATIC, &lexer->source[start_pos], len + 1, lexer->line, column);
+        if (len == 7 && strncmp(start, "private", len) == 0)
+            return make_token(TOKEN_AT_PRIVATE, &lexer->source[start_pos], len + 1, lexer->line, column);
         return make_token(TOKEN_UNKNOWN, "@", 1, lexer->line, column);
     }
 

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -62,6 +62,7 @@ typedef enum
     TOKEN_INDENT,
     TOKEN_DEDENT,
     TOKEN_AT_STATIC,
+    TOKEN_AT_PRIVATE,
     TOKEN_UNKNOWN
 } TokenType;
 

--- a/src/types/env.c
+++ b/src/types/env.c
@@ -48,7 +48,8 @@ static Variable *find_var(Env *env, const char *name)
     return var;
 }
 
-void set_variable(Env *env, const char *name, Value val)
+static void set_variable_internal(Env *env, const char *name, Value val,
+                                  bool is_private)
 {
     // Search existing variable in chain
     for (Env *e = env; e != NULL; e = e->parent)
@@ -66,7 +67,18 @@ void set_variable(Env *env, const char *name, Value val)
     Variable *new_var = malloc(sizeof(Variable));
     new_var->name = strdup(name);
     new_var->value = clone_value(&val);
+    new_var->is_private = is_private;
     HASH_ADD_KEYPTR(hh, env->vars, new_var->name, strlen(new_var->name), new_var);
+}
+
+void set_variable(Env *env, const char *name, Value val)
+{
+    set_variable_internal(env, name, val, false);
+}
+
+void set_private_variable(Env *env, const char *name, Value val)
+{
+    set_variable_internal(env, name, val, true);
 }
 
 Value get_variable(Env *env, const char *name, int line, int column)

--- a/src/types/env.h
+++ b/src/types/env.h
@@ -1,6 +1,7 @@
 #ifndef ENV_H
 #define ENV_H
 
+#include <stdbool.h>
 #include "types/value.h"
 
 #include "uthash.h"
@@ -9,6 +10,7 @@ typedef struct Variable
 {
     char *name;           // key
     Value value;          // stored value
+    bool is_private;
     UT_hash_handle hh;    // uthash handle
 } Variable;
 
@@ -24,6 +26,7 @@ void env_retain(Env *env);
 void env_release(Env *env);
 
 void set_variable(Env *env, const char *name, Value val);
+void set_private_variable(Env *env, const char *name, Value val);
 Value get_variable(Env *env, const char *name, int line, int column);
 
 #endif

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -14,5 +14,9 @@ class ImportTests(AbleTestCase):
         output = self.run_script('examples/modules/import_sqrt.abl')
         self.assertEqual(output, '3\n')
 
+    def test_custom_module(self):
+        output = self.run_script('examples/modules/import_custom.abl')
+        self.assertEqual(output, 'Hello, Codex\n')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support `@private` decorator for variables and functions
- skip private bindings when exporting modules
- example custom module and docs for importing local modules
- tests for custom module import

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688a7dfecb1483309f16343678e5aaa7