### PR TITLE
Allow importing classes from modules

### DIFF
--- a/examples/modules/import_class.abl
+++ b/examples/modules/import_class.abl
@@ -1,0 +1,3 @@
+from examples.modules.person_mod import Person
+set p to Person("Alice")
+p.greet()

--- a/examples/modules/person_mod.abl
+++ b/examples/modules/person_mod.abl
@@ -1,0 +1,5 @@
+class Person():
+    set init to (this, name):
+        this.name to name
+    set greet to (this):
+        pr("Hi ", this.name)

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -926,6 +926,8 @@ Value run_ast(ASTNode **nodes, int count)
                     fn->params[p] = strdup(method->data.method.params[p]);
                 fn->body = method->children;
                 fn->body_count = method->child_count;
+                method->children = NULL;
+                method->child_count = 0;
                 fn->env = interpreter_current_env();
                 env_retain(interpreter_current_env());
                 fn->bind_on_access = !method->is_static;

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -18,5 +18,9 @@ class ImportTests(AbleTestCase):
         output = self.run_script('examples/modules/import_custom.abl')
         self.assertEqual(output, 'Hello, Codex\n')
 
+    def test_class_import(self):
+        output = self.run_script('examples/modules/import_class.abl')
+        self.assertEqual(output, 'Hi Alice\n')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- keep method bodies alive when class definitions are loaded from modules
- add example module exporting a class
- exercise class importing in the test suite

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688b8d1c0fb48330ae75bb55c1b7d920