### PR TITLE
Add random module

### DIFF
--- a/examples/modules/import_class.abl
+++ b/examples/modules/import_class.abl
@@ -1,0 +1,3 @@
+from examples.modules.person_mod import Person
+set p to Person("Alice")
+p.greet()

--- a/examples/modules/person_mod.abl
+++ b/examples/modules/person_mod.abl
@@ -1,0 +1,5 @@
+class Person():
+    set init to (this, name):
+        this.name to name
+    set greet to (this):
+        pr("Hi ", this.name)

--- a/examples/random/rand_example.abl
+++ b/examples/random/rand_example.abl
@@ -1,0 +1,6 @@
+from random import Random
+
+# create a generator with a fixed seed
+set rng to Random(42)
+pr(rng.randint(1, 10))
+pr(rng.randint(1, 10))

--- a/lib/random/__init__.abl
+++ b/lib/random/__init__.abl
@@ -1,0 +1,1 @@
+from random.core import Random, seed, rand, randint

--- a/lib/random/core.abl
+++ b/lib/random/core.abl
@@ -1,0 +1,32 @@
+# random core functions using a simple linear congruential generator
+set RAND_MOD to 2147483648
+set RAND_A to 1103515245
+set RAND_C to 12345
+
+class Random():
+    set init to (this, seed):
+        this.state to seed % RAND_MOD
+
+    set seed to (this, s):
+        this.state to s % RAND_MOD
+
+    set next_num to (this):
+        this.state to (RAND_A * this.state + RAND_C) % RAND_MOD
+        return this.state
+
+    set rand to (this):
+        return this.next_num() / RAND_MOD
+
+    set randint to (this, lo, hi):
+        return lo + this.next_num() % (hi - lo + 1)
+
+set default_rng to Random(1)
+
+set seed to (s):
+    default_rng.seed(s)
+
+set rand to ():
+    return default_rng.rand()
+
+set randint to (lo, hi):
+    return default_rng.randint(lo, hi)

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -926,6 +926,8 @@ Value run_ast(ASTNode **nodes, int count)
                     fn->params[p] = strdup(method->data.method.params[p]);
                 fn->body = method->children;
                 fn->body_count = method->child_count;
+                method->children = NULL;
+                method->child_count = 0;
                 fn->env = interpreter_current_env();
                 env_retain(interpreter_current_env());
                 fn->bind_on_access = !method->is_static;

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -18,5 +18,9 @@ class ImportTests(AbleTestCase):
         output = self.run_script('examples/modules/import_custom.abl')
         self.assertEqual(output, 'Hello, Codex\n')
 
+    def test_class_import(self):
+        output = self.run_script('examples/modules/import_class.abl')
+        self.assertEqual(output, 'Hi Alice\n')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/test_random.py
+++ b/tests/integration/test_random.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.integration.helpers import AbleTestCase
+
+class RandomModuleTests(AbleTestCase):
+    def test_randint_deterministic(self):
+        output = self.run_script('examples/random/rand_example.abl')
+        self.assertEqual(output, '8\n1\n')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement Random class using a simple LCG
- expose default instance helpers `seed`, `rand` and `randint`
- demonstrate class import in `rand_example.abl`

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688aefd0e21c8330ae2541dd44998310