### PR TITLE
Add time module with sleep example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ from math import sqrt
 pr(sqrt(9))
 ```
 
+The `time` module offers simple timing utilities:
+
+```able
+from time import time, sleep
+set start to time()
+sleep(1)
+pr(time() - start >= 1)
+```
+
 Custom modules can also be loaded from the working directory:
 
 ```able

--- a/examples/time/sleep_example.abl
+++ b/examples/time/sleep_example.abl
@@ -1,0 +1,5 @@
+from time import time, sleep
+set start to time()
+sleep(1)
+set end to time()
+pr(end - start >= 1)

--- a/lib/time/__init__.abl
+++ b/lib/time/__init__.abl
@@ -1,0 +1,5 @@
+set time to ():
+    return time()
+
+set sleep to (seconds):
+    sleep(seconds)

--- a/tests/integration/test_time.py
+++ b/tests/integration/test_time.py
@@ -1,0 +1,10 @@
+import unittest
+from tests.integration.helpers import AbleTestCase
+
+class TimeModuleTests(AbleTestCase):
+    def test_sleep(self):
+        output = self.run_script('examples/time/sleep_example.abl')
+        self.assertEqual(output, 'true\n')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add builtin `time` and `sleep`
- create `lib/time` module
- add example script and tests for the time module
- document time utilities in README

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688bea06d2108330a418873b6f31fdda