### PR TITLE
Add list sampling utilities to random

### DIFF
--- a/examples/random/sample_example.abl
+++ b/examples/random/sample_example.abl
@@ -1,0 +1,7 @@
+from random.core import Random
+
+set rng to Random(42)
+pr(rng.choice([1, 2, 3, 4]))
+set picks to rng.sample([1, 2, 3, 4], 3)
+for v of picks:
+    pr(v)

--- a/lib/random/__init__.abl
+++ b/lib/random/__init__.abl
@@ -1,1 +1,1 @@
-from random.core import Random, seed, rand, randint
+from random.core import Random, seed, rand, randint, choice, sample

--- a/lib/random/core.abl
+++ b/lib/random/core.abl
@@ -21,6 +21,15 @@ class Random():
     set randint to (this, lo, hi):
         return lo + this.next_num() % (hi - lo + 1)
 
+    set choice to (this, seq):
+        return seq.get(this.randint(0, len(seq) - 1))
+
+    set sample to (this, seq, k):
+        set result to list()
+        for i of k:
+            result.append(this.choice(seq))
+        return result
+
 set default_seed to int(time())
 set default_rng to Random(default_seed)
 
@@ -32,3 +41,9 @@ set rand to ():
 
 set randint to (lo, hi):
     return default_rng.randint(lo, hi)
+
+set choice to (seq):
+    return default_rng.choice(seq)
+
+set sample to (seq, k):
+    return default_rng.sample(seq, k)

--- a/tests/integration/test_random.py
+++ b/tests/integration/test_random.py
@@ -6,5 +6,9 @@ class RandomModuleTests(AbleTestCase):
         output = self.run_script('examples/random/rand_example.abl')
         self.assertEqual(output, '8\n1\n')
 
+    def test_choice_and_sample(self):
+        output = self.run_script('examples/random/sample_example.abl')
+        self.assertEqual(output, '4\n1\n1\n1\n')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `choice` and `sample` functions in `random.core`
- expose new utilities from `random` package
- add example demonstrating random sampling
- cover new behavior in integration tests

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688bf9a78f388330883180df8ea80268