### PR TITLE
Add rounding functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ from math import sqrt
 pr(sqrt(9))
 ```
 
+Rounding helpers are also available:
+
+```able
+from math import ceil, round
+pr(ceil(23 / 10))
+pr(round(26 / 10))
+```
+
 The `time` module offers simple timing utilities:
 
 ```able

--- a/examples/modules/import_round.abl
+++ b/examples/modules/import_round.abl
@@ -1,0 +1,3 @@
+from math import ceil, round
+pr(ceil(23 / 10))
+pr(round(26 / 10))

--- a/lib/math/__init__.abl
+++ b/lib/math/__init__.abl
@@ -1,1 +1,1 @@
-from math.core import add, sqrt
+from math.core import add, sqrt, floor, ceil, round

--- a/lib/math/core.abl
+++ b/lib/math/core.abl
@@ -7,3 +7,20 @@ set sqrt to (x):
     while abs(guess * guess - x) > epsilon:
         guess to (guess + x / guess) / 2
     return guess
+
+set floor to (x):
+    set i to int(x)
+    if i > x:
+        return i - 1
+    return i
+
+set ceil to (x):
+    set i to int(x)
+    if i < x:
+        return i + 1
+    return i
+
+set round to (x):
+    if x >= 0:
+        return int(x + 1 / 2)
+    return int(x - 1 / 2)

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -14,6 +14,10 @@ class ImportTests(AbleTestCase):
         output = self.run_script('examples/modules/import_sqrt.abl')
         self.assertEqual(output, '3\n')
 
+    def test_math_round(self):
+        output = self.run_script('examples/modules/import_round.abl')
+        self.assertEqual(output, '3\n3\n')
+
     def test_custom_module(self):
         output = self.run_script('examples/modules/import_custom.abl')
         self.assertEqual(output, 'Hello, Codex\n')


### PR DESCRIPTION
## Summary
- implement `floor`, `ceil` and `round` helpers in `math`
- expose the helpers from the math module
- show new functionality in examples and docs
- test importing and using the rounding helpers

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688c5aa059888330963a1e7b66d7c78e