### PR TITLE
fix: remove redundant module import in name imports

### DIFF
--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -1139,8 +1139,6 @@ Value run_ast(ASTNode **nodes, int count)
         }
         case NODE_IMPORT_NAMES:
         {
-            Value mod = import_module_value(n->data.import_names.module_name,
-                                           n->line, n->column);
             for (int i = 0; i < n->data.import_names.name_count; ++i)
             {
                 Value attr = import_module_attr(n->data.import_names.module_name,


### PR DESCRIPTION
## Summary
- remove unused module value in `NODE_IMPORT_NAMES`

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688e7c0da3088330979138062fd3aa6b