### PR TITLE
Bind controller routes for server router

### DIFF
--- a/examples/server/router_build.abl
+++ b/examples/server/router_build.abl
@@ -1,0 +1,30 @@
+from server.annotations import route, get, post
+from server.router import build_routes
+
+class Request():
+    fun init(this, method, path):
+        this.method = method
+        this.path = path
+
+@route("/api")
+class UserController():
+    fun init(this):
+        this.prefix = "user"
+
+    @get
+    fun index(this, request):
+        return this.prefix + ":" + request.method
+
+    @post("/users")
+    fun create(this, request):
+        return this.prefix + ":" + request.method
+
+controllers = []
+controllers.append(UserController)
+routes = build_routes(controllers)
+pr(len(routes))
+for route of routes:
+    pr(route.method + " " + route.path)
+    request = Request(route.method, route.path)
+    response = route.handler(request)
+    pr(response)

--- a/lib/server/annotations.abl
+++ b/lib/server/annotations.abl
@@ -32,7 +32,7 @@ fun _normalize_path(path):
 fun _append_route(target, verb, path):
     meta = _ensure_meta(target)
     routes = _clone_list(meta.routes)
-    routes.append({ "verb": verb, "path": path })
+    routes.append({ "verb": verb, "path": path, "handler": target })
     meta.routes = routes
     target.__abl_server_meta__ = meta
     return target

--- a/lib/server/router.abl
+++ b/lib/server/router.abl
@@ -1,0 +1,85 @@
+from server.annotations import get_base_path, get_routes
+
+fun _to_string(value, fallback):
+    if type(value) == "UNDEFINED" or value == null:
+        return fallback
+    if type(value) == "STRING":
+        if value == "":
+            return fallback
+        return value
+    text = str(value)
+    if text == "":
+        return fallback
+    return text
+
+fun _join_path(base_path, method_path):
+    base = _to_string(base_path, "/")
+    method = _to_string(method_path, "/")
+    if base == "/":
+        if method == "/" or method == "":
+            return "/"
+        return method
+    if method == "/" or method == "":
+        return base
+    return base + method
+
+fun _is_callable(value):
+    t = type(value)
+    return t == "FUNCTION" or t == "BOUND_METHOD"
+
+fun _bind_handler(instance, handler):
+    fun bound(request):
+        return handler(instance, request)
+    return bound
+
+fun _resolve_handler(instance, handler):
+    if not _is_callable(handler):
+        return null
+    if type(handler) == "FUNCTION":
+        return _bind_handler(instance, handler)
+    return handler
+
+fun _extract_method(route):
+    method = route.method
+    if type(method) == "UNDEFINED" or method == null:
+        method = route.verb
+    if type(method) == "UNDEFINED" or method == null:
+        return null
+    return _to_string(method, "")
+
+fun _extract_path(route):
+    path = route.path
+    if type(path) == "UNDEFINED" or path == null:
+        return "/"
+    return _to_string(path, "/")
+
+fun _collect_route_records(controller_cls, instance):
+    base_path = _to_string(get_base_path(controller_cls), "/")
+    definitions = get_routes(controller_cls)
+    records = []
+    if type(definitions) == "LIST":
+        for definition of definitions:
+            method = _extract_method(definition)
+            if method == null or method == "":
+                continue
+            joined_path = _join_path(base_path, _extract_path(definition))
+            handler = _resolve_handler(instance, definition.handler)
+            if handler == null:
+                continue
+            record = {}
+            record.method = method
+            record.path = joined_path
+            record.handler = handler
+            records.append(record)
+    return records
+
+fun build_routes(registry):
+    routes = []
+    if type(registry) == "LIST":
+        for entry of registry:
+            if type(entry) == "TYPE":
+                controller_instance = entry()
+                controller_routes = _collect_route_records(entry, controller_instance)
+                for route of controller_routes:
+                    routes.append(route)
+    return routes

--- a/tests/integration/test_server_router.py
+++ b/tests/integration/test_server_router.py
@@ -1,0 +1,16 @@
+import unittest
+
+from tests.integration.helpers import AbleTestCase
+
+
+class ServerRouterTests(AbleTestCase):
+    def test_build_routes_binds_handlers(self):
+        output = self.run_script('examples/server/router_build.abl')
+        self.assertEqual(
+            output,
+            '2\nGET /api\nuser:GET\nPOST /api/users\nuser:POST\n',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- retain handler functions in annotation metadata and surface route definitions on controller classes
- update the router helper to bind controller instances, normalize paths, and return call-ready handlers
- add an executable example and integration test covering the annotation-driven router output

## Testing
- python3 run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68de13b8cd6483308055b01716a7c78b